### PR TITLE
get api url from addon config

### DIFF
--- a/AnkiHabitica/config.json
+++ b/AnkiHabitica/config.json
@@ -2,6 +2,7 @@
   "auto_earn": true,
   "barcolor": "#603960",
   "barbgcolor": "#BFBFBF",
+  "habitica_url": "https://habitica.com",
   "check_db_on_profile_load": true,
   "debug": false,
   "deckpoints": 0,

--- a/AnkiHabitica/config.md
+++ b/AnkiHabitica/config.md
@@ -17,3 +17,4 @@
 * `step`, this is how many points each tick of the progress bar represents
 * `timeboxpoints`, points earned for each 15 min "timebox"
 * `tries_eq`, this many wrong answers gives us one point
+* `habitica_url`, the URL of the Habitica instance. All API calls will be made to that URL

--- a/AnkiHabitica/habitica_api.py
+++ b/AnkiHabitica/habitica_api.py
@@ -21,12 +21,13 @@ class HabiticaAPI(object):
     TYPE_TODO = "todo"
     TYPE_REWARD = "reward"
 
-    def __init__(self, user_id, api_key):
+    def __init__(self, user_id, api_key, habitica_url):
         if ah.user_settings["keep_log"]:
             ah.log.debug("Begin function")
         self.user_id = user_id
         self.api_key = api_key
-        self.v3_url = "https://habitica.com/api/v3/"
+        self.habitica_url = habitica_url.rstrip("/") + "/"
+        self.v3_url = f"{self.habitica_url}api/v3/"
         if ah.user_settings["keep_log"]:
             ah.log.debug("End function")
 
@@ -245,7 +246,7 @@ class HabiticaAPI(object):
     def export_avatar_as_png(self):
         if ah.user_settings["keep_log"]:
             ah.log.debug("Begin function")
-        url = "http://habitica.com/export/avatar-%s.png" % self.user_id
+        url = f"{self.habitica_url}export/avatar-%s.png" % self.user_id
         req = urllib.request.Request(url)
         req.add_header('x-api-user', self.user_id)
         req.add_header('x-api-key', self.api_key)

--- a/AnkiHabitica/habitica_class.py
+++ b/AnkiHabitica/habitica_class.py
@@ -32,7 +32,7 @@ class Habitica(object):
     def __init__(self):
         if ah.user_settings["keep_log"]:
             ah.log.debug("Begin function")
-        self.api = HabiticaAPI(ah.settings.user, ah.settings.token)
+        self.api = HabiticaAPI(ah.settings.user, ah.settings.token, ah.user_settings['habitica_url'])
         self.name = 'Anki User'
         self.lvl = 0
         self.xp = 0


### PR DESCRIPTION
it still uses habitica.com as default, but now the user can edit the addon configuration to use a selfhosted habitica instance 

closes #149 